### PR TITLE
サインイン画面　認証ロジック（エラー含む）作成

### DIFF
--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Config/GlobalExceptionConfig.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Config/GlobalExceptionConfig.java
@@ -70,6 +70,7 @@ public class GlobalExceptionConfig {
     return new ResponseEntity<>(problemDetail, HttpStatus.BAD_REQUEST);
   }
 
+  // サインアップ時、メールアドレス存在エラー発生後処理
   @ExceptionHandler(EmailAlreadyRegisteredException.class)
   public ResponseEntity<ProblemDetail> handleEmailAlreadyRegisterException(EmailAlreadyRegisteredException ex,
       WebRequest request) {

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Controller/AuthController.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Controller/AuthController.java
@@ -8,6 +8,7 @@ import org.springframework.http.HttpStatus;
 import org.springframework.http.ResponseEntity;
 
 import io.github.ksk45.onlineboard.Model.Entity.User;
+import io.github.ksk45.onlineboard.Model.Form.Auth.SignInForm;
 import io.github.ksk45.onlineboard.Model.Form.Auth.SignUpForm;
 import io.github.ksk45.onlineboard.Model.Response.AuthResponseDto;
 import io.github.ksk45.onlineboard.Service.Auth.AuthService;
@@ -33,11 +34,21 @@ public class AuthController {
     // ユーザー登録
     User user = authService.regUser(signUpForm);
 
-    AuthResponseDto responseDto = AuthResponseDto.builder()
-                                  .userId(user.getUserId())
-                                  .userName(user.getUserName())
-                                  .email(user.getEmail())
-                                  .build();
+    // responseDto作成
+    AuthResponseDto responseDto = authService.createAuthResponseDto(user);
+    
+    return new ResponseEntity<AuthResponseDto>(responseDto, HttpStatus.CREATED);
+  }
+  
+  @PostMapping("/sign-in")
+  public ResponseEntity<AuthResponseDto> signIn(@Valid @RequestBody SignInForm signInForm) {
+    log.info("サインインapi呼び出し成功");
+    
+    // ユーザー取得
+    User user = authService.getUser(signInForm);
+    
+    // responseDto作成
+    AuthResponseDto responseDto = authService.createAuthResponseDto(user);
 
     return new ResponseEntity<AuthResponseDto>(responseDto, HttpStatus.CREATED);
   }

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Exception/Auth/UserNotExistsException.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Exception/Auth/UserNotExistsException.java
@@ -1,0 +1,12 @@
+package io.github.ksk45.onlineboard.Exception.Auth;
+
+import org.springframework.http.HttpStatus;
+import org.springframework.web.bind.annotation.ResponseStatus;
+
+@ResponseStatus(HttpStatus.UNAUTHORIZED)
+public class UserNotExistsException extends RuntimeException {
+  
+  public UserNotExistsException(String message) {
+    super(message);
+  }
+}

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Repository/UserRepository.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Repository/UserRepository.java
@@ -1,5 +1,6 @@
 package io.github.ksk45.onlineboard.Repository;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.data.jpa.repository.JpaRepository;
@@ -7,5 +8,18 @@ import org.springframework.data.jpa.repository.JpaRepository;
 import io.github.ksk45.onlineboard.Model.Entity.User;
 
 public interface UserRepository extends JpaRepository<User, Integer> {
+  /**
+   * メールアドレス存在チェック
+   * @param email
+   * @return Optional<User> ユーザーの存在情報
+   */
   Optional<User> findByEmail(String email);
+
+  /**
+   * メールアドレス・パスワードからユーザー情報の取得
+   * @param email
+   * @param password
+   * @return 取得したユーザー情報のList
+   */
+  List<User> findByEmailAndPassword(String email, String password);
 }

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Service/Auth/AuthService.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Service/Auth/AuthService.java
@@ -1,7 +1,9 @@
 package io.github.ksk45.onlineboard.Service.Auth;
 
 import io.github.ksk45.onlineboard.Model.Entity.User;
+import io.github.ksk45.onlineboard.Model.Form.Auth.SignInForm;
 import io.github.ksk45.onlineboard.Model.Form.Auth.SignUpForm;
+import io.github.ksk45.onlineboard.Model.Response.AuthResponseDto;
 
 public interface AuthService {
 
@@ -20,4 +22,21 @@ public interface AuthService {
    * @return UserEntity 登録したユーザーEntityを返却
    */
   public User regUser(SignUpForm signUpForm);
+
+  /**
+   * 入力ユーザー情報取得（サインイン画面）
+   * 入力ユーザーが存在しない場合、例外(UserNotExistsException)をスロー
+   *
+   * @param signInForm 入力フォーム
+   * @return User 取得したユーザーEntity
+   */
+  public User getUser(SignInForm signInForm);
+
+  /**
+   * 画面返却用Dto作成
+   * 
+   * @param User ユーザーEntity
+   * @return AuthResponseDto サインイン・サインアップ用Dto
+   */
+  public AuthResponseDto createAuthResponseDto(User user);
 }

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Service/Auth/AuthServiceImpl.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/Service/Auth/AuthServiceImpl.java
@@ -1,17 +1,23 @@
 package io.github.ksk45.onlineboard.Service.Auth;
 
+import java.util.List;
 import java.util.Optional;
 
 import org.springframework.stereotype.Service;
 
 import io.github.ksk45.onlineboard.Exception.Auth.EmailAlreadyRegisteredException;
+import io.github.ksk45.onlineboard.Exception.Auth.UserNotExistsException;
 import io.github.ksk45.onlineboard.Model.Entity.User;
+import io.github.ksk45.onlineboard.Model.Form.Auth.SignInForm;
 import io.github.ksk45.onlineboard.Model.Form.Auth.SignUpForm;
+import io.github.ksk45.onlineboard.Model.Response.AuthResponseDto;
 import io.github.ksk45.onlineboard.Repository.UserRepository;
 import lombok.RequiredArgsConstructor;
+import lombok.extern.slf4j.Slf4j;
 
 @Service
 @RequiredArgsConstructor
+@Slf4j
 public class AuthServiceImpl implements AuthService {
 
   private final UserRepository userRepository;
@@ -35,5 +41,29 @@ public class AuthServiceImpl implements AuthService {
         .build();
 
     return userRepository.save(userEntity);
+  }
+
+  @Override
+  public User getUser(SignInForm signInForm) {
+    List<User> user = userRepository.findByEmailAndPassword(signInForm.getEmail(), signInForm.getPassword());
+
+    if (user.size() == 0) {
+      throw new UserNotExistsException("{ERROR_USER_NOT_EXISTS}");
+    } else if (user.size() > 1) {
+      log.error("同一メールアドレス・パスワードで複数ユーザーがヒットしました。メールアドレス：" + signInForm.getEmail());
+      // 画面上は予期せぬエラーとして表示
+      throw new ArrayIndexOutOfBoundsException();
+    }
+
+    return user.get(0);
+  }
+
+  @Override
+  public AuthResponseDto createAuthResponseDto(User user) {
+    return AuthResponseDto.builder()
+                        .userId(user.getUserId())
+                        .userName(user.getUserName())
+                        .email(user.getEmail())
+                        .build();
   }
 }

--- a/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/model/Form/Auth/SignInForm.java
+++ b/backend/onlineboard/src/main/java/io/github/ksk45/onlineboard/model/Form/Auth/SignInForm.java
@@ -1,0 +1,15 @@
+package io.github.ksk45.onlineboard.Model.Form.Auth;
+
+import jakarta.validation.constraints.NotBlank;
+import lombok.Data;
+
+@Data
+public class SignInForm {
+  
+  @NotBlank(message = "{VALIDATION_REQUIRED}")
+
+  private String email;
+
+  @NotBlank(message = "{VALIDATION_REQUIRED}")
+  private String password;
+}

--- a/backend/onlineboard/src/main/resources/ErrorMessages.properties
+++ b/backend/onlineboard/src/main/resources/ErrorMessages.properties
@@ -1,2 +1,4 @@
 # サインアップ画面
 ERROR_EMAIL_ALREADY_REGISTERED=入力されたメールアドレスは既に登録されています
+# サインイン画面
+ERROR_USER_NOT_EXISTS=入力されたメールアドレスまたはパスワードが正しくありません

--- a/backend/onlineboard/src/main/resources/Messages.properties
+++ b/backend/onlineboard/src/main/resources/Messages.properties
@@ -3,3 +3,4 @@ name=名前
 email=メールアドレス
 passNew=パスワード
 passConf=確認用パスワード
+password=パスワード

--- a/frontend/src/components/Auth/Form/GuestForm.tsx
+++ b/frontend/src/components/Auth/Form/GuestForm.tsx
@@ -10,6 +10,7 @@ const GuestForm = () => {
   // useState定義
   const [name, setName] = useState("");
   const [nameErr, setNameErr] = useState("");
+  const [commonErrMessage, setCommonErrMessage] = useState("");
 
   // ユーザーコンテキスト取得
   const userContext = useUser();
@@ -34,18 +35,25 @@ const GuestForm = () => {
     // バリデーションチェック
     if (!isValid()) return;
 
+    // フォーム送信前にすべてのエラーメッセージをクリア
+    setNameErr("");
+    setCommonErrMessage("");
+
     userContext.setUser({
       userId: -1,
       userName: name,
       email: "guest",
     });
     navigate("/menu");
-    // alert(`name: ${name}\nログイン処理成功（ダミー）`)
-
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {commonErrMessage && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-sm">
+          {commonErrMessage}
+        </div>
+      )}
       <AuthInput
         errorMessage={nameErr}
         type="name"

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -66,7 +66,9 @@ const SignInForm = (props: SignInFormProps) => {
   const setErrorMessage = () => {
     if (errorMessage) {
       return (
-        <div className=""></div>
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-sm">
+          {errorMessage}
+        </div>
       )
     } else {
       return <></>

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -68,7 +68,7 @@ const SignInForm = (props: SignInFormProps) => {
     e.preventDefault();
     // バリデーションチェック
     if (!isValid()) return;
-    const res = await fetch("/api/login", {
+    const res = await fetch("/api/auth/sign-in", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
       body: JSON.stringify({ email, password }),

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import type { AuthMode } from "../../../types/auth";
 import {
+  setUserAuthErrorMessage,
   validateEmailFormat,
   validateMaxLength,
   validateMinLength,
@@ -24,7 +25,7 @@ const SignInForm = (props: SignInFormProps) => {
   const [password, setPassword] = useState("");
   const [emailErr, setEmailErr] = useState("");
   const [passwordErr, setPasswordErr] = useState("");
-  const errorMessage = false;
+  const [commonErrMessage, setCommonErrMessage] = useState("");
 
   // ユーザーコンテキスト取得
   const userContext = useUser();
@@ -62,25 +63,16 @@ const SignInForm = (props: SignInFormProps) => {
     setPasswordErr(errorData.password || "");
   }
 
-  // POSTエラー時（ユーザー検出不可）、エラーセット
-  const setErrorMessage = () => {
-    if (errorMessage) {
-      return (
-        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-sm">
-          {errorMessage}
-        </div>
-      )
-    } else {
-      return <></>
-    }
-  }
-
-
-
   // POSTapi呼び出し
   const handleSubmit = async (e: React.FormEvent) => {
     // submitのデフォルト挙動（ページ遷移）をキャンセル
     e.preventDefault();
+
+    // フォーム送信前にすべてのエラーメッセージをクリア
+    setEmailErr("");
+    setPasswordErr("");
+    setCommonErrMessage("");
+
     // バリデーションチェック
     if (!isValid()) return;
     const res = await fetch("/api/auth/sign-in", {
@@ -99,16 +91,14 @@ const SignInForm = (props: SignInFormProps) => {
       navigate("/menu");
     } else {
       const errorData = await res.json();
-      if (res.status === 400 || res.status === 401) {
+      if (res.status === 400) {
         if (errorData.fieldErrors) {
-          if (res.status === 400) {
-            fieldErrorSet(errorData.fieldErrors);
-          } else {
-            // 共通エラーフィールドにエラーメッセージをセット
-          }
+          fieldErrorSet(errorData.fieldErrors);
         } else {
           alert(`予期せぬエラーが発生しました`);
         }
+      } else if (res.status === 401) {
+        setCommonErrMessage(setUserAuthErrorMessage())
       } else {
         alert(`予期せぬエラーが発生しました`);
       }
@@ -117,7 +107,11 @@ const SignInForm = (props: SignInFormProps) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
-      {errorMessage ? setErrorMessage() : <></>}
+      {commonErrMessage && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-sm">
+          {commonErrMessage}
+        </div>
+      )}
       <AuthInput
         type="email"
         errorMessage={emailErr}

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -24,6 +24,7 @@ const SignInForm = (props: SignInFormProps) => {
   const [password, setPassword] = useState("");
   const [emailErr, setEmailErr] = useState("");
   const [passwordErr, setPasswordErr] = useState("");
+  const errorMessage = false;
 
   // ユーザーコンテキスト取得
   const userContext = useUser();
@@ -60,6 +61,18 @@ const SignInForm = (props: SignInFormProps) => {
     setEmailErr(errorData.email || "");
     setPasswordErr(errorData.password || "");
   }
+
+  // POSTエラー時（ユーザー検出不可）、エラーセット
+  const setErrorMessage = () => {
+    if (errorMessage) {
+      return (
+        <div className=""></div>
+      )
+    } else {
+      return <></>
+    }
+  }
+
 
 
   // POSTapi呼び出し
@@ -102,6 +115,7 @@ const SignInForm = (props: SignInFormProps) => {
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {errorMessage ? setErrorMessage() : <></>}
       <AuthInput
         type="email"
         errorMessage={emailErr}

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -86,7 +86,11 @@ const SignInForm = (props: SignInFormProps) => {
       const errorData = await res.json();
       if (res.status === 400 || res.status === 401) {
         if (errorData.fieldErrors) {
-          fieldErrorSet(errorData.fieldErrors);
+          if (res.status === 400) {
+            fieldErrorSet(errorData.fieldErrors);
+          } else {
+            // 共通エラーフィールドにエラーメッセージをセット
+          }
         } else {
           alert(`予期せぬエラーが発生しました`);
         }

--- a/frontend/src/components/Auth/Form/SignInForm.tsx
+++ b/frontend/src/components/Auth/Form/SignInForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import type { AuthMode } from "../../../types/auth";
 import {
+  setUnexpectedErrorMessage,
   setUserAuthErrorMessage,
   validateEmailFormat,
   validateMaxLength,
@@ -95,12 +96,12 @@ const SignInForm = (props: SignInFormProps) => {
         if (errorData.fieldErrors) {
           fieldErrorSet(errorData.fieldErrors);
         } else {
-          alert(`予期せぬエラーが発生しました`);
+          setCommonErrMessage(setUnexpectedErrorMessage())
         }
       } else if (res.status === 401) {
         setCommonErrMessage(setUserAuthErrorMessage())
       } else {
-        alert(`予期せぬエラーが発生しました`);
+        setCommonErrMessage(setUnexpectedErrorMessage())
       }
     }
   };

--- a/frontend/src/components/Auth/Form/SignUpForm.tsx
+++ b/frontend/src/components/Auth/Form/SignUpForm.tsx
@@ -1,6 +1,7 @@
 import React, { useState } from "react";
 import type { AuthMode } from "../../../types/auth";
 import {
+  setUnexpectedErrorMessage,
   validateEmailFormat,
   validateLength,
   validateMaxLength,
@@ -29,7 +30,7 @@ const SignUpForm = (props: SignUpFormProps) => {
   const [emailErr, setEmailErr] = useState("");
   const [passNewErr, setPassNewErr] = useState("");
   const [passConfErr, setPassConfErr] = useState("");
-
+  const [commonErrMessage, setCommonErrMessage] = useState("");
   // ユーザーコンテキスト取得
   const userContext = useUser();
 
@@ -96,6 +97,14 @@ const SignUpForm = (props: SignUpFormProps) => {
     e.preventDefault();
     // バリデーションチェック
     if (!isValid()) return;
+
+    // フォーム送信前にすべてのエラーメッセージをクリア
+    setNameErr("");
+    setEmailErr("");
+    setPassNewErr("");
+    setPassConfErr("");
+    setCommonErrMessage("");
+
     const res = await fetch("/api/auth/sign-up", {
       method: "POST",
       headers: { "Content-Type": "application/json" },
@@ -116,16 +125,21 @@ const SignUpForm = (props: SignUpFormProps) => {
         if (errorData.fieldErrors) {
           fieldErrorSet(errorData.fieldErrors);
         } else {
-          alert(`予期せぬエラーが発生しました`);
+          setCommonErrMessage(setUnexpectedErrorMessage())
         }
       } else {
-        alert(`予期せぬエラーが発生しました`);
+        setCommonErrMessage(setUnexpectedErrorMessage())
       }
     }
   };
 
   return (
     <form onSubmit={handleSubmit} className="space-y-4">
+      {commonErrMessage && (
+        <div className="bg-red-50 border border-red-200 text-red-700 px-4 py-3 rounded-xl text-sm">
+          {commonErrMessage}
+        </div>
+      )}
       <AuthInput
         type="name"
         errorMessage={nameErr}

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -29,3 +29,7 @@ export const validatePasswordMatch = (value: string, valueConf: string) =>
 // ユーザー認証エラー時のエラーメッセージセット
 export const setUserAuthErrorMessage = () =>
   `入力されたメールアドレスまたはパスワードが正しくありません。`;
+
+// 予期せぬエラー時のエラーメッセージセット
+export const setUnexpectedErrorMessage = () =>
+  `予期せぬエラーが発生しました。`;

--- a/frontend/src/utils/validation.ts
+++ b/frontend/src/utils/validation.ts
@@ -22,5 +22,10 @@ export const validateEmailFormat = (value: string, message = "有効なメール
 export const validatePasswordComplexity = (value: string, message = "英字と数字を両方含めてください") =>
   /[a-zA-Z]/.test(value) && /[0-9]/.test(value) ? "" : message;
 
-export const validatePasswordMatch = (value: string, valueConf: string) => 
+// validation パスワード一致チェック
+export const validatePasswordMatch = (value: string, valueConf: string) =>
   value !== valueConf ? `パスワードが一致しません` : "";
+
+// ユーザー認証エラー時のエラーメッセージセット
+export const setUserAuthErrorMessage = () =>
+  `入力されたメールアドレスまたはパスワードが正しくありません。`;


### PR DESCRIPTION
## 概要
- ユーザー認証ロジック追加
- サインイン画面エラー（ユーザー・パスワード存在なし）制御
- 共通エラーメッセージエリア追加

## 主な変更点
- `frontend/src/components/Auth/Form/SignInForm.tsx`：共通エラーメッセージエリア追加
- `frontend/src/components/Auth/Form/SignUpForm.tsx`：共通エラーメッセージエリア追加
- `frontend/src/components/Auth/Form/GuestForm.tsx`：共通エラーメッセージエリア追加
- `Service/Auth/AuthServiceImpl.java`：ユーザー認証ロジック追加